### PR TITLE
Analyze and implement streaming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,29 @@ message("Hi")
 
 ![img.png](docs/img.png)
 
+## Streaming (docs-style)
+
+Use the `message_stream` helper to stream text as it arrives. It updates a single message in-place using a stable `key`, similar to the Streamlit docs examples.
+
+```python
+from st_chat_message import message_stream
+
+# chunks can be any iterable of text deltas
+final_text = message_stream(
+    chunks,
+    is_user=False,
+    key="assistant_stream",
+    rich_content=True,   # set False for fastest updates
+    throttle_ms=25,      # minimum ms between UI updates
+    flush_every=1,       # emit every N chunks
+)
+```
+
+- **rich_content**: when True (default), renders Markdown (LaTeX, tables, code). Set to False for faster re-renders while streaming.
+- The final full text is returned once the stream finishes.
+
+See `examples/generator_streaming.py` for a simple generator-based demo, and `examples/openai_streaming.py` for OpenAI streaming.
+
 ## Buiding from source
 
 ### Prerequisites

--- a/examples/generator_streaming.py
+++ b/examples/generator_streaming.py
@@ -1,0 +1,53 @@
+import time
+import streamlit as st
+
+from st_chat_message import message, message_stream
+
+
+def char_stream(text: str, delay_s: float = 0.02):
+    for ch in text:
+        yield ch
+        time.sleep(delay_s)
+
+
+st.set_page_config(page_title="st-chat-message: Generator Streaming", page_icon="💬")
+
+user_prompt = st.text_input("Ask something", value="Show me streaming with markdown, please")
+
+if "conversation" not in st.session_state:
+    st.session_state.conversation = []
+
+if st.button("Send"):
+    st.session_state.conversation.append({"role": "user", "content": user_prompt})
+
+for i, msg in enumerate(st.session_state.conversation):
+    message(msg["content"], is_user=(msg["role"] == "user"), key=f"msg_{i}")
+
+if st.session_state.conversation and st.session_state.conversation[-1]["role"] == "user":
+    # Demo assistant reply with streaming
+    reply = r"""
+Here is some **markdown** with code, math, and a table:
+
+```python
+print("Hello streaming!")
+```
+
+$E = mc^2$
+
+| A | B |
+|---|---|
+| 1 | 2 |
+| 3 | 4 |
+"""
+
+    final_text = message_stream(
+        char_stream(reply, delay_s=0.01),
+        is_user=False,
+        key="assistant_stream",
+        rich_content=True,
+        throttle_ms=25,
+        flush_every=2,
+    )
+
+    # Store the final assistant message in the conversation
+    st.session_state.conversation.append({"role": "assistant", "content": final_text})

--- a/examples/openai_streaming.py
+++ b/examples/openai_streaming.py
@@ -1,0 +1,69 @@
+import os
+import streamlit as st
+
+from st_chat_message import message, message_stream
+
+try:
+    from openai import OpenAI
+except Exception:
+    OpenAI = None  # type: ignore
+
+
+st.set_page_config(page_title="st-chat-message: OpenAI Streaming", page_icon="🤖")
+
+api_key = os.getenv("OPENAI_API_KEY", "")
+model = st.sidebar.text_input("OpenAI Chat Model", value="gpt-4o-mini")
+temperature = st.sidebar.slider("Temperature", 0.0, 2.0, 0.7, 0.1)
+
+if not api_key:
+    st.info("Set OPENAI_API_KEY in your environment to run this demo.")
+
+if "chat" not in st.session_state:
+    st.session_state.chat = []  # list[dict(role, content)]
+
+prompt = st.text_input("Message", value="Stream a short assistant response.")
+
+if st.button("Send") and prompt:
+    st.session_state.chat.append({"role": "user", "content": prompt})
+
+for i, msg in enumerate(st.session_state.chat):
+    message(msg["content"], is_user=(msg["role"] == "user"), key=f"cmsg_{i}")
+
+if st.session_state.chat and st.session_state.chat[-1]["role"] == "user" and api_key and OpenAI is not None:
+    client = OpenAI(api_key=api_key)
+
+    # Construct messages history for context
+    history = [
+        {"role": m["role"], "content": m["content"]}
+        for m in st.session_state.chat
+    ]
+
+    # Call the Chat Completions API with streaming enabled
+    stream = client.chat.completions.create(
+        model=model,
+        messages=history,
+        temperature=temperature,
+        stream=True,
+    )
+
+    def text_deltas():
+        for event in stream:
+            # OpenAI Python SDK v1: choices[].delta.content contains text fragments
+            for choice in getattr(event, "choices", []) or []:
+                delta = getattr(choice, "delta", None)
+                if not delta:
+                    continue
+                content = getattr(delta, "content", None)
+                if content:
+                    yield content
+
+    final = message_stream(
+        text_deltas(),
+        is_user=False,
+        key="openai_stream",
+        rich_content=True,
+        throttle_ms=20,
+        flush_every=1,
+    )
+
+    st.session_state.chat.append({"role": "assistant", "content": final})

--- a/examples/streaming.py
+++ b/examples/streaming.py
@@ -40,6 +40,7 @@ I can also display tabular data.
 if "n_chars" not in st.session_state:
     st.session_state.n_chars = 1
 
+# Prefer the new generator-based helper in generator_streaming.py
 message(msg1[:st.session_state.n_chars], partial=st.session_state.n_chars < len(msg1), key="message_1")
 
 # Simulate streaming


### PR DESCRIPTION
Add `message_stream` helper and `rich_content` flag to enable ergonomic, docs-style streaming for chat messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-b52ec9cc-9522-4486-ad34-e5a9a0f8ed7f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b52ec9cc-9522-4486-ad34-e5a9a0f8ed7f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

